### PR TITLE
Add area ratio parameter

### DIFF
--- a/R/AFM.math.R
+++ b/R/AFM.math.R
@@ -11,12 +11,14 @@ AFM.math.params <- function(obj) {
   Ra = get.Ra(obj@data$z[[1]])
   Rq = get.Rq(obj@data$z[[1]])
   Hsd = get.Hsd(obj@data$z[[1]])
+  AR = get.AR(obj@data$z[[1]])
   structure(
     list(
       basename = basename(obj@fullFilename),
       Ra = Ra,
       Rq = Rq,
-      Hsd = Hsd
+      Hsd = Hsd,
+      AR = AR
     ),
     class = 'AFMmath'
   )
@@ -36,6 +38,7 @@ summary.AFMmath <- function(object, ...) {
   cat("Roughness Ra = ", object$Ra," nm \n")
   cat("Roughness Rq = ", object$Rq," nm \n")
   cat("Standard Deviation of Height Hsd = ", object$Hsd," nm \n")
+  cat("Deep Area Ratio = ", object$AR,"\n")
 }
 
 
@@ -48,3 +51,11 @@ get.Ra <- function(z) { sum(abs(z-mean(z)))/length(z) }
 get.Rq <- function(z) { sqrt(sum((z-mean(z))^2)/length(z)) }
 # computes the standard deviation in height Hsd
 get.Hsd <- function(z) {sd(z)}
+# computes the ratio of pin hole area (height lower than 3 sigma) to total area through pixel counting
+get.AR <- function(z) {
+  count <- 0
+  for (val in z) {
+    if(val <= -3*Hsd)  count = count+1
+  }
+ar = count/length(z)
+return(ar)}


### PR DESCRIPTION
uses 3 sigma as definition for a "deep area" 
uses pixel counting